### PR TITLE
Fixes for 4.0.0-snake-island-alpha-021

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,10 +2,10 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fable-py": {
-      "version": "4.0.0-alpha-032",
+    "fable": {
+      "version": "4.0.0-snake-island-alpha-021",
       "commands": [
-        "fable-py"
+        "fable"
       ]
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .fake
 .ionide
 .vs
+.idea

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -5,7 +5,7 @@ open Fake.IO
 open Fake.Core
 open System.Xml
 
-module List = 
+module List =
     let exec xs = List.iter (fun task -> task()) xs
 
 
@@ -54,7 +54,7 @@ let cleanDirectories() = Shell.deleteDirs [
     path [ tests; "obj" ]
 ]
 
-let cleanPythonFiles() = 
+let cleanPythonFiles() =
     let srcPythonFiles = System.IO.Directory.GetFiles(src, "*.py")
     let testPythonFiles = System.IO.Directory.GetFiles(tests, "*.py")
     Array.iter Shell.rm srcPythonFiles
@@ -62,8 +62,8 @@ let cleanPythonFiles() =
 
 let clean() = List.exec [cleanDirectories; cleanPythonFiles]
 
-let test() = 
-    dotnet "fable-py" tests "Compiling the tests project to Python failed"
+let test() =
+    dotnet "fable --lang py" tests "Compiling the tests project to Python failed"
     python "program.py" tests "Running the tests failed"
 
 [<EntryPoint>]

--- a/src/Fable.SimpleJson.Python.fsproj
+++ b/src/Fable.SimpleJson.Python.fsproj
@@ -22,6 +22,6 @@
     <Content Include="*.fsproj; *.fs" Exclude="Program.fs" PackagePath="fable\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Python" Version="0.17.0" />
+    <PackageReference Include="Fable.Python" Version="0.20.0" />
   </ItemGroup>
 </Project>

--- a/src/Json.Converter.fs
+++ b/src/Json.Converter.fs
@@ -141,7 +141,7 @@ module Convert =
         | JString value, TypeInfo.Float32 when value.ToLower() = "nan" -> unbox (Double.NaN)
         | JString value, TypeInfo.Float32 -> unbox (float32 value)
         // reading number as int -> floor it
-        | JNumber value, TypeInfo.Int32 -> unbox (JS.Math.floor(value))
+        | JNumber value, TypeInfo.Int32 -> unbox (Math.Floor(value))
         | JBool value, TypeInfo.Bool -> unbox value
         // reading int from string -> parse it
         | JString value, TypeInfo.Int32 -> unbox (int value)
@@ -165,7 +165,7 @@ module Convert =
         | JString value, TypeInfo.UInt32 -> unbox (uint32 value)
         | JNumber value, TypeInfo.UInt64 -> unbox (uint64 value)
         | JString value, TypeInfo.UInt64 -> unbox (uint64 value)
-        | JNumber value, TypeInfo.TimeSpan -> unbox (JS.Math.floor value)
+        | JNumber value, TypeInfo.TimeSpan -> unbox (Math.Floor value)
         | JString value, TypeInfo.Enum getlElemType ->
             let (underlyingType, originalType) = getlElemType()
             match underlyingType with

--- a/src/SimpleJson.fs
+++ b/src/SimpleJson.fs
@@ -3,7 +3,6 @@ namespace Fable.SimpleJson.Python
 open System
 
 open Fable.Core
-open Fable.Import
 open Fable.Python.Json
 
 module InteropUtil =


### PR DESCRIPTION
This PR adds fixes for Fable 4.0.0-snake-island-alpha-021:

- Now using the normal `fable` tool instead of the deprecated `fable-py`
- Removes some `JS.Math.Floor` that do not work with Python anymore